### PR TITLE
Add community guidelines documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at `security@growthjar.io`. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at the [Contributor Covenant translations](https://www.contributor-covenant.org/translations).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to GrowthJar
+
+Thank you for your interest in contributing to GrowthJar! We welcome contributions from the community and are committed to making the process as smooth as possible. Please take a moment to review the guidelines below before opening an issue or submitting a pull request.
+
+## Table of Contents
+- [Code of Conduct](#code-of-conduct)
+- [Project Setup](#project-setup)
+- [How to Contribute](#how-to-contribute)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Suggesting Enhancements](#suggesting-enhancements)
+  - [Submitting Changes](#submitting-changes)
+- [Branching Strategy](#branching-strategy)
+- [Coding Standards](#coding-standards)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Commit Messages](#commit-messages)
+- [Pull Requests](#pull-requests)
+- [Community Support](#community-support)
+
+## Code of Conduct
+By participating in this project you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). Please report unacceptable behavior to `security@growthjar.io`.
+
+## Project Setup
+1. Fork the repository and clone your fork.
+2. Install dependencies for both the server and client packages:
+   ```bash
+   cd server && npm install
+   cd ../client && npm install
+   ```
+3. Copy `.env.example` to `.env` in both workspaces and provide the required configuration values.
+4. Use `docker-compose` when you need local database services.
+
+## How to Contribute
+
+### Reporting Bugs
+- Use the issue template provided and include environment details, steps to reproduce, expected behavior, and screenshots/logs when relevant.
+- Do not disclose security vulnerabilities publicly. Follow the [security policy](./SECURITY.md).
+
+### Suggesting Enhancements
+- Before opening a new feature request, check for existing issues or discussions.
+- Describe the problem you are trying to solve, not just the solution.
+- Provide UI/UX mockups or API contracts if available.
+
+### Submitting Changes
+- Open an issue to discuss significant work before investing time in a solution.
+- Ensure that your change is scoped to a single feature/fix.
+
+## Branching Strategy
+- Create branches from `main` using the following naming conventions:
+  - `feature/<name>` for new features.
+  - `fix/<name>` for bug fixes.
+  - `chore/<name>` for maintenance tasks.
+- Keep branches up to date with `main` and resolve conflicts before opening a pull request.
+
+## Coding Standards
+- Use JavaScript with ES Modules (`import`/`export`).
+- Follow the feature-based folder structure (e.g., `client/src/features/<feature>` and `server/src/modules/<feature>`).
+- Apply linting and formatting via ESLint and Prettier.
+- Write JSDoc for all public functions, services, and API handlers.
+- Keep shared types in `shared/types` aligned with server and client implementations.
+
+## Testing
+- Write unit and integration tests using Jest and React Testing Library.
+- Ensure critical flows (auth, payments, uploads) have end-to-end coverage when modified.
+- All tests must pass before submitting a pull request.
+
+## Documentation
+- Update `/docs` and related markdown files (`CHANGELOG.md`, `API-SPECS.md`, `DB-SCHEMA.md`, etc.) whenever behavior or APIs change.
+- Provide README updates within new features/modules describing their purpose and usage.
+
+## Commit Messages
+- Use present tense and keep messages concise (e.g., `Add enrollment controller validation`).
+- Reference related issues using `Fixes #123` where appropriate.
+- Do not commit secrets or environment files.
+
+## Pull Requests
+- Describe what changed, why, and how it was tested.
+- Include screenshots or screen recordings for UI changes.
+- Request at least one reviewer and address all review feedback promptly.
+- Ensure the PR title is descriptive and follows semantic conventions when possible.
+
+## Community Support
+If you need help or have questions, open a GitHub Discussion or join the community channel (link shared in the README). For sensitive topics (security or conduct), contact the maintainers at `security@growthjar.io`.
+
+We appreciate your contributions and for helping make GrowthJar better for everyone!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,36 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+The GrowthJar team actively maintains the latest minor release of the `main` branch. We provide security updates for:
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version               | Supported          |
+| --------------------- | ------------------ |
+| `main` branch         | :white_check_mark: |
+| Latest minor release  | :white_check_mark: |
+| Older releases        | :x:                |
+
+Security patches are generally backported to the most recent release train when technically feasible. Versions that have reached end-of-life will not receive fixes.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you discover a security vulnerability, please do **not** create a public issue. Instead:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+1. Email the security team at `security@growthjar.io` with the subject line `SECURITY`. Use encrypted communication if possible.
+2. Provide a detailed description of the vulnerability, including steps to reproduce, affected components, and potential impact.
+3. Include any proof-of-concept code, logs, or screenshots that help demonstrate the issue.
+
+We aim to acknowledge receipt within **2 business days** and will provide status updates at least once per week until the issue is resolved.
+
+## Disclosure Process
+
+- After validating the report, we will work with you to develop a fix and coordinate a release.
+- Please allow us reasonable time to deploy the fix before publicly disclosing the issue (a 90-day embargo is typical, though urgent cases may be resolved sooner).
+- Credit will be given to reporters who request acknowledgment in the release notes, unless anonymity is preferred.
+
+## Scope
+
+The security policy applies to all code, infrastructure, and services hosted within the GrowthJar GitHub organization, including the `client`, `server`, and any supporting tooling defined in this repository.
+
+## Non-Security Issues
+
+For non-security bugs, feature requests, or general questions, please use GitHub Issues or Discussions instead of the security channel.


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING guide outlining workflow expectations for GrowthJar contributors
- include the Contributor Covenant v2.1 code of conduct for community standards
- refresh the security policy with reporting instructions and supported version scope

## Testing
- not run